### PR TITLE
Prioritize VIP queue players when filling slots

### DIFF
--- a/RetakesPlugin/Modules/Managers/QueueManager.cs
+++ b/RetakesPlugin/Modules/Managers/QueueManager.cs
@@ -229,7 +229,7 @@ public class QueueManager
             // Ordered by players with queue priority flag first since they
             // have queue priority.
             var playersToAddList = QueuePlayers
-                .OrderBy(player => Helpers.HasQueuePriority(player, _queuePriorityFlags) ? 1 : 0)
+                .OrderByDescending(player => Helpers.HasQueuePriority(player, _queuePriorityFlags))
                 .Take(playersToAdd)
                 .ToList();
 


### PR DESCRIPTION
## Summary
- ensure queue fills open slots by ordering queue players with priority flags first

## Testing
- ⚠️ `dotnet build` *(fails: dotnet command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe70f8e888322877684e5391ab178