### PR TITLE
Add configuration flag for queue priority immunity

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ When the plugin is first loaded it will create a `retakes_config.json` file in t
 | ShouldOpenDoors                                   | Whether to open doors on round start (People are noticing rare crashes when this is enabled).                                                   | false      | false      | true       |
 | IsAutoPlantEnabled                                | Whether to enable auto bomb planting at the start of the round or not.                                                                          | true       | false      | true       |
 | QueuePriorityFlag                                 | A comma separated list of CSS flags for queue priority.                                                                                         | @css/vip   | n/a        | n/a        |
+| ShouldQueuePriorityPlayersBeImmune                | Whether queue priority players keep their slot when the server is full.
+                                                                       | true       | false      | true       |
 | IsDebugMode                                       | Whether to enable debug output to the server console or not.                                                                                    | false      | false      | true       |
 | ShouldForceEvenTeamsWhenPlayerCountIsMultipleOf10 | Whether to force even teams when the active players is a multiple of 10 or not. (this means you will get 5v5 @ 10 players / 10v10 @ 20 players) | true       | false      | true       |
 | EnableFallbackBombsiteAnnouncement                | Whether to enable the fallback bombsite announcement.                                                                                           | true       | false      | true       |

--- a/RetakesPlugin/Modules/Configs/RetakesConfigData.cs
+++ b/RetakesPlugin/Modules/Configs/RetakesConfigData.cs
@@ -2,7 +2,7 @@
 
 public class RetakesConfigData
 {
-    public static int CurrentVersion = 11;
+    public static int CurrentVersion = 12;
 
     public int Version { get; set; } = CurrentVersion;
     public int MaxPlayers { get; set; } = 9;
@@ -16,6 +16,7 @@ public class RetakesConfigData
     public bool ShouldOpenDoors { get; set; } = false;
     public bool IsAutoPlantEnabled { get; set; } = true;
     public string QueuePriorityFlag { get; set; } = "@css/vip";
+    public bool ShouldQueuePriorityPlayersBeImmune { get; set; } = true;
     public bool IsDebugMode { get; set; } = false;
     public bool ShouldForceEvenTeamsWhenPlayerCountIsMultipleOf10 { get; set; } = true;
     public bool EnableFallbackBombsiteAnnouncement { get; set; } = true;

--- a/RetakesPlugin/Modules/Managers/QueueManager.cs
+++ b/RetakesPlugin/Modules/Managers/QueueManager.cs
@@ -11,6 +11,7 @@ public class QueueManager
     private readonly string[] _queuePriorityFlags;
     private readonly bool _shouldForceEvenTeamsWhenPlayerCountIsMultipleOf10;
     private readonly bool _shouldPreventTeamChangesMidRound;
+    private readonly bool _shouldQueuePriorityPlayersBeImmune;
 
     public HashSet<CCSPlayerController> QueuePlayers = [];
     public HashSet<CCSPlayerController> ActivePlayers = [];
@@ -21,7 +22,8 @@ public class QueueManager
         float? retakesTerroristRatio,
         string? queuePriorityFlags,
         bool? shouldForceEvenTeamsWhenPlayerCountIsMultipleOf10,
-        bool? shouldPreventTeamChangesMidRound
+        bool? shouldPreventTeamChangesMidRound,
+        bool? shouldQueuePriorityPlayersBeImmune
     )
     {
         _translator = translator;
@@ -30,6 +32,7 @@ public class QueueManager
         _queuePriorityFlags = queuePriorityFlags?.Split(",").Select(flag => flag.Trim()).ToArray() ?? ["@css/vip"];
         _shouldForceEvenTeamsWhenPlayerCountIsMultipleOf10 = shouldForceEvenTeamsWhenPlayerCountIsMultipleOf10 ?? true;
         _shouldPreventTeamChangesMidRound = shouldPreventTeamChangesMidRound ?? true;
+        _shouldQueuePriorityPlayersBeImmune = shouldQueuePriorityPlayersBeImmune ?? true;
     }
 
     public int GetTargetNumTerrorists()
@@ -156,6 +159,12 @@ public class QueueManager
 
     private void HandleQueuePriority()
     {
+        if (!_shouldQueuePriorityPlayersBeImmune)
+        {
+            Helpers.Debug("Queue priority immunity disabled, skipping.");
+            return;
+        }
+
         Helpers.Debug($"handling queue priority.");
         if (ActivePlayers.Count != _maxRetakesPlayers)
         {

--- a/RetakesPlugin/RetakesPlugin.cs
+++ b/RetakesPlugin/RetakesPlugin.cs
@@ -599,7 +599,8 @@ public class RetakesPlugin : BasePlugin
                 _retakesConfig?.RetakesConfigData?.TerroristRatio,
                 _retakesConfig?.RetakesConfigData?.QueuePriorityFlag,
                 _retakesConfig?.RetakesConfigData?.ShouldForceEvenTeamsWhenPlayerCountIsMultipleOf10,
-                _retakesConfig?.RetakesConfigData?.ShouldPreventTeamChangesMidRound
+                _retakesConfig?.RetakesConfigData?.ShouldPreventTeamChangesMidRound,
+                _retakesConfig?.RetakesConfigData?.ShouldQueuePriorityPlayersBeImmune
             ),
             _retakesConfig?.RetakesConfigData?.RoundsToScramble,
             _retakesConfig?.RetakesConfigData?.IsScrambleEnabled,

--- a/RetakesPlugin/retakes_config.json
+++ b/RetakesPlugin/retakes_config.json
@@ -1,0 +1,21 @@
+{
+  "Version": 12,
+  "MaxPlayers": 9,
+  "TerroristRatio": 0.45,
+  "RoundsToScramble": 5,
+  "IsScrambleEnabled": true,
+  "EnableFallbackAllocation": true,
+  "EnableBombsiteAnnouncementVoices": false,
+  "EnableBombsiteAnnouncementCenter": true,
+  "ShouldBreakBreakables": false,
+  "ShouldOpenDoors": false,
+  "IsAutoPlantEnabled": true,
+  "QueuePriorityFlag": "@css/vip",
+  "ShouldQueuePriorityPlayersBeImmune": true,
+  "IsDebugMode": false,
+  "ShouldForceEvenTeamsWhenPlayerCountIsMultipleOf10": true,
+  "EnableFallbackBombsiteAnnouncement": true,
+  "ShouldRemoveSpectators": true,
+  "IsBalanceEnabled": true,
+  "ShouldPreventTeamChangesMidRound": true
+}


### PR DESCRIPTION
## Summary
- add a ShouldQueuePriorityPlayersBeImmune configuration flag and bump the config version
- plumb the flag through QueueManager so queue priority swaps can be disabled
- document the new option and update the sample retakes_config.json

## Testing
- not run (dotnet is not installed in the container)


------
https://chatgpt.com/codex/tasks/task_e_68cfe7ce3bbc8322bce4589279f280c1