### PR TITLE
Add queue priority immunity configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,11 @@ When the plugin is first loaded it will create a `retakes_config.json` file in t
 | ShouldBreakBreakables                             | Whether to break all breakable props on round start (People are noticing rare crashes when this is enabled).                                    | false      | false      | true       |
 | ShouldOpenDoors                                   | Whether to open doors on round start (People are noticing rare crashes when this is enabled).                                                   | false      | false      | true       |
 | IsAutoPlantEnabled                                | Whether to enable auto bomb planting at the start of the round or not.                                                                          | true       | false      | true       |
-| QueuePriorityFlag                                 | A comma separated list of CSS flags for queue priority.                                                                                         | @css/vip   | n/a        | n/a        |
-| ShouldQueuePriorityPlayersBeImmune                | Whether queue priority players keep their slot when the server is full.
-                                                                       | true       | false      | true       |
+| QueuePriorityFlag                                 | A comma separated list of CSS flags for queue priority.                                                                       | @css/vip   | n/a        | n/a        |
+| QueuePriorityImmuneFlag                           | A comma separated list of CSS flags that should never be replaced during queue priority swaps. Only applied when `ShouldQueuePriorityPlayersBeImmune` is true.
+                                                                      | "" (none) | n/a        | n/a        |
+| ShouldQueuePriorityPlayersBeImmune                | Whether queue priority players keep their slot when the server is full. When enabled, both queue priority and queue priority immune flags keep their slot.
+                                                       | true       | false      | true       |
 | IsDebugMode                                       | Whether to enable debug output to the server console or not.                                                                                    | false      | false      | true       |
 | ShouldForceEvenTeamsWhenPlayerCountIsMultipleOf10 | Whether to force even teams when the active players is a multiple of 10 or not. (this means you will get 5v5 @ 10 players / 10v10 @ 20 players) | true       | false      | true       |
 | EnableFallbackBombsiteAnnouncement                | Whether to enable the fallback bombsite announcement.                                                                                           | true       | false      | true       |

--- a/RetakesPlugin/Modules/Configs/RetakesConfigData.cs
+++ b/RetakesPlugin/Modules/Configs/RetakesConfigData.cs
@@ -1,8 +1,12 @@
-﻿namespace RetakesPlugin.Modules.Configs;
+using System;
+using System.Linq;
+using System.Text.Json.Serialization;
+
+namespace RetakesPlugin.Modules.Configs;
 
 public class RetakesConfigData
 {
-    public static int CurrentVersion = 12;
+    public static int CurrentVersion = 13;
 
     public int Version { get; set; } = CurrentVersion;
     public int MaxPlayers { get; set; } = 9;
@@ -16,6 +20,7 @@ public class RetakesConfigData
     public bool ShouldOpenDoors { get; set; } = false;
     public bool IsAutoPlantEnabled { get; set; } = true;
     public string QueuePriorityFlag { get; set; } = "@css/vip";
+    public string QueuePriorityImmuneFlag { get; set; } = string.Empty;
     public bool ShouldQueuePriorityPlayersBeImmune { get; set; } = true;
     public bool IsDebugMode { get; set; } = false;
     public bool ShouldForceEvenTeamsWhenPlayerCountIsMultipleOf10 { get; set; } = true;
@@ -23,4 +28,27 @@ public class RetakesConfigData
     public bool ShouldRemoveSpectators { get; set; } = true;
     public bool IsBalanceEnabled { get; set; } = true;
     public bool ShouldPreventTeamChangesMidRound { get; set; } = true;
+
+    [JsonIgnore]
+    public string[] QueuePriorityFlags => ParseFlags(QueuePriorityFlag, ["@css/vip"]);
+
+    [JsonIgnore]
+    public string[] QueuePriorityImmuneFlags => ParseFlags(QueuePriorityImmuneFlag, Array.Empty<string>());
+
+    private static string[] ParseFlags(string? flags, string[] defaultFlags)
+    {
+        if (string.IsNullOrWhiteSpace(flags))
+        {
+            return defaultFlags;
+        }
+
+        var parsedFlags = flags
+            .Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(flag => flag.Trim())
+            .Where(flag => !string.IsNullOrWhiteSpace(flag))
+            .ToArray();
+
+        return parsedFlags.Length > 0 ? parsedFlags : defaultFlags;
+    }
+
 }

--- a/RetakesPlugin/Modules/Helpers.cs
+++ b/RetakesPlugin/Modules/Helpers.cs
@@ -356,16 +356,31 @@ public static class Helpers
         beam.DispatchSpawn();
     }
 
-    public static bool HasQueuePriority(CCSPlayerController player, string[] queuePriorityFlags)
+    private static bool PlayerHasAnyFlag(CCSPlayerController player, string[] flags)
     {
-        foreach (var queuePriorityFlag in queuePriorityFlags)
+        if (flags.Length == 0)
         {
-            if (AdminManager.PlayerHasPermissions(player, queuePriorityFlag))
+            return false;
+        }
+
+        foreach (var flag in flags)
+        {
+            if (AdminManager.PlayerHasPermissions(player, flag))
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    public static bool HasQueuePriority(CCSPlayerController player, string[] queuePriorityFlags)
+    {
+        return PlayerHasAnyFlag(player, queuePriorityFlags);
+    }
+
+    public static bool HasQueuePriorityImmunity(CCSPlayerController player, string[] queuePriorityImmuneFlags)
+    {
+        return PlayerHasAnyFlag(player, queuePriorityImmuneFlags);
     }
 }

--- a/RetakesPlugin/RetakesPlugin.cs
+++ b/RetakesPlugin/RetakesPlugin.cs
@@ -597,7 +597,8 @@ public class RetakesPlugin : BasePlugin
                 _translator,
                 _retakesConfig?.RetakesConfigData?.MaxPlayers,
                 _retakesConfig?.RetakesConfigData?.TerroristRatio,
-                _retakesConfig?.RetakesConfigData?.QueuePriorityFlag,
+                _retakesConfig?.RetakesConfigData?.QueuePriorityFlags,
+                _retakesConfig?.RetakesConfigData?.QueuePriorityImmuneFlags,
                 _retakesConfig?.RetakesConfigData?.ShouldForceEvenTeamsWhenPlayerCountIsMultipleOf10,
                 _retakesConfig?.RetakesConfigData?.ShouldPreventTeamChangesMidRound,
                 _retakesConfig?.RetakesConfigData?.ShouldQueuePriorityPlayersBeImmune

--- a/RetakesPlugin/retakes_config.json
+++ b/RetakesPlugin/retakes_config.json
@@ -1,5 +1,5 @@
 {
-  "Version": 12,
+  "Version": 13,
   "MaxPlayers": 9,
   "TerroristRatio": 0.45,
   "RoundsToScramble": 5,
@@ -11,6 +11,7 @@
   "ShouldOpenDoors": false,
   "IsAutoPlantEnabled": true,
   "QueuePriorityFlag": "@css/vip",
+  "QueuePriorityImmuneFlag": "",
   "ShouldQueuePriorityPlayersBeImmune": true,
   "IsDebugMode": false,
   "ShouldForceEvenTeamsWhenPlayerCountIsMultipleOf10": true,


### PR DESCRIPTION
## Summary
- add a configurable `QueuePriorityImmuneFlag` and bump the config version with helpers that parse CSV flags
- update the queue manager and helpers to respect immunity flags when replacing players
- document the new option in the README

## Testing
- dotnet build RetakesPlugin/RetakesPlugin.csproj *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d19ac762e48322a31ea5f5258c2fce